### PR TITLE
Upgrade from pySBOL to pySBOL2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,7 @@ name: Tests
 on:
 
   push:
-    branches: [ main, master, dev ]
-    paths:
-      - '**.py'
   pull_request:
-    branches: [ main, master ]
 
 jobs:
 

--- a/dnaweaver_synbiocad/get_assembly_plan_from_sbol.py
+++ b/dnaweaver_synbiocad/get_assembly_plan_from_sbol.py
@@ -1,5 +1,9 @@
-from sbml2sbol import sbol
+import sbol2 as sbol
 from collections import OrderedDict
+
+def id_sort(i: iter):
+    """Sort a collection of SBOL objects and/or URIs by identity URI"""
+    return sorted(i, key=lambda x: x.identity if isinstance(x, sbol.Identified) else x)
 
 
 def get_assembly_plan_from_sbol(sbol_doc=None, path=None):
@@ -27,13 +31,14 @@ def get_assembly_plan_from_sbol(sbol_doc=None, path=None):
         for seq in sbol_doc.sequences
     }
     parts_per_construct = [
-        (component.displayId.replace('_sequence', '').replace('_seq', ''), [c.displayId[:-2] for c in component.components])
+        (component.displayId.replace('_sequence', '').replace('_seq', ''),
+         [c.displayId[:-2] for c in id_sort(component.components)])
         for component in sbol_doc.componentDefinitions
         if len(component.components)
     ]
 
     constructs_sequences = [
-        (construct_name, "".join([parts_sequences[part] for part in parts]))
+        (construct_name, "".join([parts_sequences[part] for part in id_sort(parts)]))
         for construct_name, parts in parts_per_construct
     ]
     parts_per_construct = OrderedDict(parts_per_construct)

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,4 +9,4 @@ dependencies:
   - pandas
   - requests
   - openpyxl
-  - sbml2sbol>=0.1.13
+  - pysbol2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-dnaweaver==0.3.1
-pySBOL==2.3.3.post7
-openpyxl==2.5.7
-xlrd==1.1.0
-xlwt==1.2.0
+dnaweaver
+sbol2
+openpyxl
+xlrd
+xlwt
 docopt
 flask
 flask_restful
+requests

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -16,7 +16,7 @@ def get_sheet_length(filepath, sheet_name):
 
 
 def run_test_with_assembly_method(output_path, assembly_method):
-    script_path = "python -m dnaweaver_synbiocad"
+    script_path = "python3 -m dnaweaver_synbiocad"
     input_path = os.path.join(
         this_directory,
         'data',


### PR DESCRIPTION
Switch to pySBOL2.

Also, correct a bug caused by the fragile assumption that set-valued properties will always be in alphabetical order when loaded, which is not (and has never been) guaranteed.

Also change test to ensure that it runs python3, unpin out of date requirements, and run tests in all actions